### PR TITLE
Private ips only

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ Module Input Variables
 - `cidrs` - Comma-separated list of private subnet CIDR blocks
 - `azs` - Comma-separated list of availability zones
 - `public_subnet_ids` - Comma-separated list of public subnet ids where NAT gateway will be created
-- `nat_gateways_count` - Number of NAT gateways to create (shoud be at least 1). For high-availability make it equal to public subnets.
+- `nat_gateways_count` - Number of NAT gateways to create (should be at least 1). For high-availability make it equal to public subnets.
+- `map_public_ip_on_launch` - Boolean that controls the subnets ability to assign public ip addresses (default=true).
 
 Usage
 -----

--- a/main.tf
+++ b/main.tf
@@ -11,13 +11,17 @@ variable "public_subnet_ids" {
 }
 variable "nat_gateways_count" {
 }
+variable "map_public_ip_on_launch" {
+  default = true
+}
 
 # Subnet
 resource "aws_subnet" "private" {
-  vpc_id            = "${var.vpc_id}"
-  cidr_block        = "${element(split(",", var.cidrs), count.index)}"
-  availability_zone = "${element(split(",", var.azs), count.index)}"
-  count             = "${length(split(",", var.cidrs))}"
+  vpc_id                  = "${var.vpc_id}"
+  cidr_block              = "${element(split(",", var.cidrs), count.index)}"
+  availability_zone       = "${element(split(",", var.azs), count.index)}"
+  count                   = "${length(split(",", var.cidrs))}"
+  map_public_ip_on_launch = "${var.map_public_ip_on_launch}"
 
   tags {
     Name = "${var.name}.${element(split(",", var.azs), count.index)}"


### PR DESCRIPTION
Expose aws_subnet.map_public_ip_on_launch as var.map_public_ip_on_launch in order to control public ip creation in private subnet. The value is defaulted to `true` for backwards compatibility however I could argue it should be defaulted to `false` as I can't think of any common use case for a machine in a private subnet to have a public ip address. 
