### PR TITLE
Change var.public_subnet_ids to more correct name var.private_subnet_ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ Module Input Variables
 - `vpc_id` - VPC id
 - `cidrs` - List of private subnet CIDR blocks
 - `azs` - List of availability zones
-- `public_subnet_ids` - List of public subnet ids where NAT gateway will be created
-- `nat_gateways_count` - Number of NAT gateways to create (should be at least 1). For high-availability make it equal to public subnets.
-- `map_public_ip_on_launch` - Boolean that controls the subnets ability to assign public ip addresses (default=true).
+- `private_subnet_ids` - List of private subnet ids where NAT gateway will be created
+- `nat_gateways_count` - Number of NAT gateways to create (should be at least 1). For high-availability make it equal to the length of list `private_subnet_ids`.
+- `map_public_ip_on_launch` - Boolean that controls the subnets ability to assign public ip addresses (default=false).
 
 Usage
 -----

--- a/main.tf
+++ b/main.tf
@@ -11,14 +11,14 @@ variable "azs" {
 }
 variable "vpc_id" {
 }
-variable "public_subnet_ids" {
-  description = "A list of public subnet ids"
+variable "private_subnet_ids" {
+  description = "A list of private subnet ids"
   default     = []
 }
 variable "nat_gateways_count" {
 }
 variable "map_public_ip_on_launch" {
-  default = true
+  default = false
 }
 
 # Subnet
@@ -69,7 +69,7 @@ resource "aws_eip" "nat" {
 
 resource "aws_nat_gateway" "nat" {
   allocation_id = "${element(aws_eip.nat.*.id, count.index)}"
-  subnet_id     = "${element(var.public_subnet_ids, count.index)}"
+  subnet_id     = "${element(var.private_subnet_ids, count.index)}"
   count         = "${var.nat_gateways_count}"
 }
 


### PR DESCRIPTION
also fix surprising default setting for map_public_ip_on_launch from true to false.

This feels like a public module that got renamed, but not all the names got changed.